### PR TITLE
5897行缺少逗号造成歧义，易误解为完全相反的意思

### DIFF
--- a/subtitles/1. Logistics, iOS 8 Overview.srt
+++ b/subtitles/1. Logistics, iOS 8 Overview.srt
@@ -5894,7 +5894,7 @@ crashes your program, so if you use exclamation point to unwrap an optional,
 1224
 01:01:39,857 --> 01:01:45,660
 and that optional's current value is not set, nil, then it will crash your program.
-并且这个 optional 的 currentTitle 没有设值为 nil 的时候，你的程序会崩溃 
+并且这个 optional 的 currentTitle 没有设值，为 nil 的时候，你的程序会崩溃 
 
 1225
 01:01:46,930 --> 01:01:50,498


### PR DESCRIPTION
and that optional's current value is not set, nil, then it will crash your program.
并且这个 optional 的 currentTitle 没有设值为 nil 的时候，你的程序会崩溃 

修改为:并且这个 optional 的 currentTitle 没有设值，为 nil 的时候，你的程序会崩溃